### PR TITLE
Adding node_modules to .gitignore since this is a reusable module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+


### PR DESCRIPTION
Convention as I understand it is to check in `node_modules` to an app, but not check it in to a reusable module.
